### PR TITLE
🛡️ Sentinel: [CRITICAL/HIGH] Fix Unprotected Exported Receiver

### DIFF
--- a/.jules/sentinel.md
+++ b/.jules/sentinel.md
@@ -1,0 +1,4 @@
+## 2024-05-23 - [Restricting Exported BroadcastReceiver for ADB Usage]
+**Vulnerability:** Unprotected `exported=true` receiver allows any malicious app to trigger Bluetooth actions.
+**Learning:** For apps intended to be controlled via ADB, the receiver must be exported, but can be secured by requiring `android.permission.DUMP`, which is held by the `shell` user but not standard apps.
+**Prevention:** Always add `android:permission="android.permission.DUMP"` (or similar shell-only permission) to exported receivers designed for ADB automation.

--- a/app/src/main/AndroidManifest.xml
+++ b/app/src/main/AndroidManifest.xml
@@ -32,7 +32,9 @@
         <receiver
             android:name=".BluetoothControlReceiver"
             android:enabled="true"
-            android:exported="true">
+            android:exported="true"
+            android:permission="android.permission.DUMP">
+            <!-- Restricted to DUMP permission (held by shell/root) to prevent other apps from triggering -->
             <intent-filter>
                 <action android:name="com.saihgupr.btcontrol.ACTION_CONNECT" />
                 <action android:name="com.saihgupr.btcontrol.ACTION_DISCONNECT" />

--- a/app/src/main/java/com/saihgupr/btcontrol/DeviceAdapter.java
+++ b/app/src/main/java/com/saihgupr/btcontrol/DeviceAdapter.java
@@ -10,6 +10,11 @@ import androidx.recyclerview.widget.RecyclerView;
 import com.google.android.material.button.MaterialButton;
 import java.util.ArrayList;
 import java.util.List;
+import android.Manifest;
+import android.content.Context;
+import android.content.pm.PackageManager;
+import android.os.Build;
+import androidx.core.content.ContextCompat;
 
 public class DeviceAdapter extends RecyclerView.Adapter<DeviceAdapter.DeviceViewHolder> {
 
@@ -40,7 +45,22 @@ public class DeviceAdapter extends RecyclerView.Adapter<DeviceAdapter.DeviceView
     @Override
     public void onBindViewHolder(@NonNull DeviceViewHolder holder, int position) {
         BluetoothDevice device = devices.get(position);
-        holder.nameText.setText(device.getName() != null ? device.getName() : "Unknown Device");
+        Context context = holder.itemView.getContext();
+
+        String deviceName = "Unknown Device";
+        if (Build.VERSION.SDK_INT < Build.VERSION_CODES.S ||
+            ContextCompat.checkSelfPermission(context, Manifest.permission.BLUETOOTH_CONNECT) == PackageManager.PERMISSION_GRANTED) {
+            try {
+                String name = device.getName();
+                if (name != null) deviceName = name;
+            } catch (SecurityException e) {
+                deviceName = "Unknown (Perm)";
+            }
+        } else {
+            deviceName = "Unknown (No Perm)";
+        }
+
+        holder.nameText.setText(deviceName);
         holder.addressText.setText(device.getAddress());
 
         holder.connectButton.setOnClickListener(v -> {


### PR DESCRIPTION
🚨 Severity: HIGH
💡 Vulnerability: The `BluetoothControlReceiver` was exported without any permission checks, allowing any app on the device to trigger Bluetooth connect/disconnect actions.
🎯 Impact: A malicious app could disrupt the user's Bluetooth connectivity or connect to unwanted devices without authorization.
🔧 Fix: Restricted the receiver by requiring `android.permission.DUMP`, which is held by the shell user (ADB) and system but not standard apps. Also added runtime permission checks for `BLUETOOTH_CONNECT` on Android 12+ to prevent crashes and ensure compliance.
✅ Verification: Verified via lint checks and code review. Verified that the permission check logic is correct for the intended ADB usage.

---
*PR created automatically by Jules for task [12521743918878894828](https://jules.google.com/task/12521743918878894828) started by @saihgupr*